### PR TITLE
Escrita de logs no InfluxDB de forma assíncrona

### DIFF
--- a/pocs/v2/ApiBroker/src/ApiBroker.API/Broker/Orquestrador.cs
+++ b/pocs/v2/ApiBroker/src/ApiBroker.API/Broker/Orquestrador.cs
@@ -17,6 +17,7 @@ public class Orquestrador
     private readonly IConfiguration _configuration;
     private readonly MetricasDao _metricasDao;
     private readonly Requisitor _requisitor;
+    private readonly Ranqueador _ranqueador;
 
     private bool SucessoNaRequisicao { get; set; }
     private int QtdeProvedoresTentados { get; set; }
@@ -26,11 +27,13 @@ public class Orquestrador
     public Orquestrador(
         IConfiguration configuration,
         MetricasDao metricasDao,
-        Requisitor requisitor)
+        Requisitor requisitor,
+        Ranqueador ranqueador)
     {
         _configuration = configuration;
         _metricasDao = metricasDao;
         _requisitor = requisitor;
+        _ranqueador = ranqueador;
 
         SucessoNaRequisicao = false;
         QtdeProvedoresTentados = 0;
@@ -141,8 +144,7 @@ public class Orquestrador
 
     private async Task<List<string>> ObterOrdemMelhoresProvedores(SolicitacaoDto solicitacao)
     {
-        var ranqueador = new Ranqueador();
-        var todosProvedoresDisponiveis =  await ranqueador.ObterOrdemMelhoresProvedores(solicitacao, _configuration);
+        var todosProvedoresDisponiveis =  await _ranqueador.ObterOrdemMelhoresProvedores(solicitacao, _configuration);
 
         return solicitacao.TentarTodosProvedoresAteSucesso
             ? todosProvedoresDisponiveis
@@ -171,7 +173,7 @@ public class Orquestrador
             Sucesso = respostaProvedor?.IsSuccessStatusCode ?? false,
             Origem = "RequisicaoCliente"
         };
-        _metricasDao.LogRespostaProvedor(logDto, _configuration);
+        _metricasDao.LogRespostaProvedor(logDto);
     }
 
     private void LogPerformanceBroker(string nomeRecurso, string provedorSelecionado,
@@ -186,7 +188,7 @@ public class Orquestrador
             TempoRespostaProvedores = tempoRespostaProvedores,
             TempoRespostaTotal = tempoRespostaTotal
         };
-        _metricasDao.LogPerformanceBroker(logDto, _configuration);
+        _metricasDao.LogPerformanceBroker(logDto);
     }
 
     private async Task NotificarUi(HttpContext context, string[] provedoresDisponiveis, string provedorAlvo)

--- a/pocs/v2/ApiBroker/src/ApiBroker.API/Healthcheck/Healthchecker.cs
+++ b/pocs/v2/ApiBroker/src/ApiBroker.API/Healthcheck/Healthchecker.cs
@@ -59,7 +59,7 @@ public class Healthchecker
     private void LogResultado(string nomeRecurso, ProvedorSettings provedor,
         HttpResponseMessage resultadoCheck, long tempoRespostaMs, IConfiguration configuration)
     {
-        var monitorador = new MetricasDao();
+        var monitorador = new MetricasDao(configuration);
         var logDto = new LogRespostaProvedorDto
         {
             NomeRecurso = nomeRecurso,
@@ -68,6 +68,6 @@ public class Healthchecker
             Sucesso = resultadoCheck.IsSuccessStatusCode,
             Origem = "Healthcheck"
         };
-        monitorador.LogRespostaProvedor(logDto, configuration);
+        monitorador.LogRespostaProvedor(logDto);
     }
 }

--- a/pocs/v2/ApiBroker/src/ApiBroker.API/Program.cs
+++ b/pocs/v2/ApiBroker/src/ApiBroker.API/Program.cs
@@ -1,7 +1,7 @@
-using System.Net.Quic;
 using ApiBroker.API.Broker;
 using ApiBroker.API.Dados;
 using ApiBroker.API.Inicializacao;
+using ApiBroker.API.Ranqueamento;
 using ApiBroker.API.Requisicao;
 using ApiBroker.API.TestHelpers;
 using ApiBroker.API.WebSocket;
@@ -19,6 +19,7 @@ Log.Information("Iniciando Broker...");
 builder.Services.AddScoped<Orquestrador>();
 builder.Services.AddScoped<MetricasDao>();
 builder.Services.AddScoped<Requisitor>();
+builder.Services.AddScoped<Ranqueador>();
 builder.Services.AddWebSocket(configuration);
 
 builder.Services.AddHttpClient("Requisitor");

--- a/pocs/v2/ApiBroker/src/ApiBroker.API/Ranqueamento/Ranqueador.cs
+++ b/pocs/v2/ApiBroker/src/ApiBroker.API/Ranqueamento/Ranqueador.cs
@@ -6,6 +6,13 @@ namespace ApiBroker.API.Ranqueamento;
 
 public class Ranqueador
 {
+    private readonly MetricasDao _metricasDao;
+
+    public Ranqueador(MetricasDao metricasDao)
+    {
+        _metricasDao = metricasDao;
+    }
+    
     public async Task<List<string>> ObterOrdemMelhoresProvedores(SolicitacaoDto solicitacao, IConfiguration configuration)
     {
         Log.Information("Iniciando processo para obter ordem dos provedores");
@@ -31,8 +38,7 @@ public class Ranqueador
 
     private async Task<List<Dictionary<string, object>>> ObterTodosProvedores(string nomeRecurso, IConfiguration configuration)
     {
-        var metricasDao = new MetricasDao();
-        return await metricasDao.ObterDadosProvedores(nomeRecurso, configuration);
+        return await _metricasDao.ObterDadosProvedores(nomeRecurso);
     }
 
 }

--- a/pocs/v2/ApiBroker/src/ApiBroker.API/appsettings.Development.json
+++ b/pocs/v2/ApiBroker/src/ApiBroker.API/appsettings.Development.json
@@ -1,7 +1,7 @@
 {
   "InfluxDbSettings": {
     "Url": "http://localhost:8086",
-    "Token": "LAlPqGkoQjQFvLrYc4h0JZR5howr_E0eYcwX3S7hHm3febWo0u7VDSEMnYl_5_vwoLHPXI1cqu-XGlfwCaIxjA=="
+    "Token": "il7CqmNcu_TGpfsCaT8l9eYUbOuxUJFAr76hF9IDOUivVhTE44X3jCVZbG5spZpfzt3i4zGyEaWCgq87ClRmEQ=="
   },
   "PortalSettings": {
     "Host": "http://localhost:3000"


### PR DESCRIPTION
Esse ajuste na escrita no InfluxDB já resolveu todos os erros do teste de carga.

Os demais ajustes (próximos PRs) serão para melhorar o tempo de execução, que agora está na casa de 2 segundos.

<img width="959" alt="Captura de Tela 2023-05-16 às 13 02 14" src="https://github.com/pedrofgd/tcc-mack/assets/50634340/d010f09d-cd8c-4871-afa7-d37e59dbc52d">
